### PR TITLE
Initialize project structure and add basic Terraform EC2 configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,10 @@
 # Local .terraform directories
 .terraform/
+.terraform.lock.hcl
 
 # .tfstate files
+terraform.tfstate
+terraform.tfstate.backup
 *.tfstate
 *.tfstate.*
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,69 @@
 # terraform-aws-starter-stack
+
 A small Terraform project to learn the basics of infrastructure as code using AWS.
+
+- This version creates a single EC2 instance in the default VPC using Terraform. The instance runs a tiny HTTP server that serves a simple hello page.
+
+## Prerequisites
+
+- Terraform 1.8 or later
+- An AWS account
+- AWS credentials configured locally (for example with `aws configure`, environment variables, or AWS SSO)
+
+## Files
+
+- `providers.tf`  
+  Configures the AWS provider and region, and sets default tags.
+- `variables.tf`  
+  Defines input variables such as the EC2 instance type.
+- `main.tf`  
+  Looks up a recent Amazon Linux 2 AMI and creates a single EC2 instance with a small HTTP server.
+- `outputs.tf`  
+  Prints the public IP and DNS of the instance after apply.
+
+## Usage
+
+Initialize Terraform:
+
+```bash
+terraform init
+```
+
+Format and validate configuration:
+
+```bash
+terraform fmt
+terraform validate
+```
+
+See what Terraform plans to create:
+
+```bash
+terraform plan
+```
+
+Apply the changes:
+
+```bash
+terraform apply
+```
+
+Type yes to confirm. When the apply completes, Terraform will output the instance_public_ip and instance_public_dns values.
+
+Open the DNS name in your browser:
+
+```bash
+http://<instance_public_dns>
+```
+
+You should see:
+
+```bash
+Hello from terraform-aws-starter-stack!
+```
+
+To clean everything up:
+
+```bash
+terraform destroy
+```

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,45 @@
+# lookup a recent Amazon linux 2 AMI in the region
+data "aws_ami" "amazon_linux_2" {
+  # get the latest AMI
+  most_recent = true
+
+  # filter by AMI name pattern
+  filter {
+    name   = "name"
+    values = ["amzn2-ami-hvm-*-x86_64-gp2"]
+  }
+
+  # filter by virtualization type hvm(hardware virtual machine)
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  # restrict to AMIs owned by amazon
+  owners = ["137112412989"] # Amazon's owner ID
+}
+
+# a single ec2 instance in the default VPC(Virtual Private Cloud)
+resource "aws_instance" "starter" {
+  # use the id of the AMI from above
+  ami = data.aws_ami.amazon_linux_2.id
+
+  instance_type = var.instance_type # this is t3.micro here by default
+
+  # assign a public ip automatically
+  associate_public_ip_address = true
+
+  # script to install and start apache httpd
+  user_data = <<-EOF
+              #!/bin/bash
+              yum install -y httpd
+              echo "Hello from terraform-aws-starter-stack!" > /var/www/html/index.html
+              systemctl enable httpd
+              systemctl start httpd
+              EOF
+
+  # for identification in console
+  tags = {
+    Name = "starter-ec2"
+  }
+}

--- a/notes.md
+++ b/notes.md
@@ -1,0 +1,53 @@
+# notes
+
+## files overview
+
+### main.tf
+
+purpose – declare actual infrastructure resources you want terraform to create (ec2 instances, s3 buckets, vpcs, etc.).
+
+contents – resource blocks (resource "aws_instance" "starter" { ... }), data sources.
+
+### providers.tf
+
+purpose – which cloud or service providers terraform should talk to (aws, gcp, azure, etc.), and configures them.
+
+contents – terraform { required_providers { ... } } plus provider "aws" { region = var.aws_region }.
+
+### variables.tf
+
+purpose – input variables that make configuration flexible and reusable.
+
+contents – variable blocks (variable "aws_region" { ... }, variable "instance_type" { ... }).
+
+### outputs.tf
+
+purpose – defines which values terraform should display after a run and optionally expose to other modules. it’s the “reporting file” that surfaces details of the infrastructure.
+
+contents – output blocks (output "instance_public_ip" { ... }) that reference attributes from resources or data sources.
+
+## general syntax
+
+### data
+
+tells terraform you’re not creating a new resource, but instead looking up or reading existing information from aws
+
+### aws_ami
+
+specifies the type of data source. here it means, query amazon machine images (amis) from aws
+
+### amazon_linux_2
+
+this is the local name for this data source
+
+### resource
+
+tells terraform that this block defines a resource to be provisioned.
+
+### aws_instance
+
+the resource type - here it means an ec2 instance in aws. each resource type corresponds to a specific aws service (aws_s3_bucket, aws_vpc, etc.).
+
+### starter
+
+the local name given to this resource.

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,11 @@
+# output for the EC2 instance public ip
+output "instance_public_ip" {
+  description = "public ip address of the starter ec2 instance"
+  value       = aws_instance.starter.public_ip # starter defined in main.tf
+}
+
+# output for the EC2 instance public DNS
+output "instance_public_dns" {
+  description = "public dns name of the starter ec2 instance"
+  value       = aws_instance.starter.public_dns # starter defined in main.tf
+}

--- a/providers.tf
+++ b/providers.tf
@@ -1,0 +1,31 @@
+# settings and provider requirements
+terraform {
+  # cli version 
+  required_version = ">= 1.8.0"
+
+  # which providers are needed
+  required_providers {
+    aws = {
+      # aws provider here is the hashicorp registry
+      source = "hashicorp/aws"
+      # aws provider version
+      version = "~> 5.0"
+    }
+  }
+}
+
+# configure aws provider
+provider "aws" {
+  # use aws_region variable
+  region = var.aws_region
+
+  # apply tags to all aws resources created by this provider automatically without having to repeat
+  default_tags {
+    tags = {
+      # project name
+      Project = "terraform-aws-starter-stack"
+      # indicate managed by terraform
+      ManagedBy = "terraform"
+    }
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,13 @@
+# variable for aws region, this way you can pass in any region at runtime
+variable "aws_region" {
+  description = "AWS region to deploy resources into"
+  type        = string
+  # default region
+  default = "us-east-1"
+}
+
+variable "instance_type" {
+  description = "EC2 instance type for the starter stack"
+  type        = string
+  default     = "t3.micro"
+}


### PR DESCRIPTION
## Summary
This PR introduces Version 0 of the terraform-aws-starter-stack project.

It sets up the initial Terraform configuration and project structure needed to build and manage AWS infrastructure using infrastructure-as-code.

## Summary of Changes

- Added Terraform project structure:
  - .gitignore
  - providers.tf
  - main.tf
  - variables.tf
  - outputs.tf

- Configured AWS provider with region and default tags
- Added data source to fetch the latest Amazon Linux 2 AMI dynamically
- Created a basic EC2 instance in the default VPC
- Added simple user_data script to start Apache and serve a "Hello from terraform-aws-starter-stack!" page
- Added output values for EC2 public IP and DNS

- Verified setup using:
  - terraform init
  - terraform plan
  - terraform apply

- Added README documentation for usage and setup